### PR TITLE
Added Vector Tiles Implementation of Roads API for Better Loading

### DIFF
--- a/backend/app/api/roads.py
+++ b/backend/app/api/roads.py
@@ -1,14 +1,19 @@
 import json
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, Response
+from sqlalchemy import bindparam, text
 from sqlalchemy.exc import OperationalError
-from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from ..db import get_db
 
 
 router = APIRouter(tags=["roads"])
+
+MVT_MEDIA_TYPE = "application/vnd.mapbox-vector-tile"
+MVT_CACHE_CONTROL = "public, max-age=60"
+MVT_EXTENT = 4096
+MVT_BUFFER = 64
 
 
 def _parse_json(value):
@@ -22,6 +27,31 @@ def _validate_bbox(min_lon, min_lat, max_lon, max_lat):
         raise HTTPException(status_code=400, detail="minLon must be less than maxLon")
     if min_lat >= max_lat:
         raise HTTPException(status_code=400, detail="minLat must be less than maxLat")
+
+
+def _validate_tile_coordinates(z, x, y):
+    max_index = (1 << z) - 1
+    if x < 0 or y < 0 or x > max_index or y > max_index:
+        raise HTTPException(status_code=400, detail="Tile coordinates out of range for zoom level")
+
+
+def _tile_profile(z):
+    if z <= 8:
+        return ("motorway", "trunk", "primary"), 80
+    if z <= 11:
+        return ("motorway", "trunk", "primary", "secondary", "tertiary"), 30
+    if z <= 13:
+        return (
+            "motorway",
+            "trunk",
+            "primary",
+            "secondary",
+            "tertiary",
+            "residential",
+            "unclassified",
+            "service",
+        ), 10
+    return None, 0
 
 
 def _execute(db, query, params):
@@ -164,6 +194,138 @@ def get_road_stats(
         "total": sum(counts.values()),
         "highway_counts": counts,
     }
+
+
+@router.get("/tiles/roads/{z}/{x}/{y}.mvt")
+def get_road_tiles(
+    z: int = Path(..., ge=0, le=22),
+    x: int = Path(..., ge=0),
+    y: int = Path(..., ge=0),
+    db: Session = Depends(get_db),
+):
+    _validate_tile_coordinates(z, x, y)
+
+    highways, simplify_tolerance = _tile_profile(z)
+    highway_filter = ""
+    query_params = {
+        "z": z,
+        "x": x,
+        "y": y,
+        "extent": MVT_EXTENT,
+        "buffer": MVT_BUFFER,
+        "simplify_tolerance": simplify_tolerance,
+    }
+
+    tile_query = text(
+        f"""
+        WITH bounds AS (
+            SELECT
+                ST_TileEnvelope(:z, :x, :y) AS tile_3857,
+                ST_Transform(ST_TileEnvelope(:z, :x, :y), 4326) AS tile_4326
+        ),
+        filtered AS (
+            SELECT
+                rs.id,
+                rs.osm_id,
+                rs.name,
+                rs.highway,
+                rs.length_m,
+                CASE
+                    WHEN :simplify_tolerance > 0 THEN
+                        ST_SimplifyPreserveTopology(ST_Transform(rs.geom, 3857), :simplify_tolerance)
+                    ELSE
+                        ST_Transform(rs.geom, 3857)
+                END AS geom_3857,
+                bounds.tile_3857
+            FROM road_segments_4326 rs
+            CROSS JOIN bounds
+            WHERE rs.geom && bounds.tile_4326
+              AND ST_Intersects(rs.geom, bounds.tile_4326)
+              {highway_filter}
+        ),
+        tile_features AS (
+            SELECT
+                id,
+                osm_id,
+                name,
+                highway,
+                length_m,
+                ST_AsMVTGeom(
+                    geom_3857,
+                    tile_3857,
+                    extent => :extent,
+                    buffer => :buffer,
+                    clip_geom => true
+                ) AS geom
+            FROM filtered
+        )
+        SELECT COALESCE(ST_AsMVT(tile_features, 'roads', :extent, 'geom'), ''::bytea) AS tile
+        FROM tile_features
+        WHERE geom IS NOT NULL
+        """
+    )
+
+    if highways:
+        highway_filter = "AND rs.highway IN :highway_values"
+        tile_query = text(
+            f"""
+            WITH bounds AS (
+                SELECT
+                    ST_TileEnvelope(:z, :x, :y) AS tile_3857,
+                    ST_Transform(ST_TileEnvelope(:z, :x, :y), 4326) AS tile_4326
+            ),
+            filtered AS (
+                SELECT
+                    rs.id,
+                    rs.osm_id,
+                    rs.name,
+                    rs.highway,
+                    rs.length_m,
+                    CASE
+                        WHEN :simplify_tolerance > 0 THEN
+                            ST_SimplifyPreserveTopology(ST_Transform(rs.geom, 3857), :simplify_tolerance)
+                        ELSE
+                            ST_Transform(rs.geom, 3857)
+                    END AS geom_3857,
+                    bounds.tile_3857
+                FROM road_segments_4326 rs
+                CROSS JOIN bounds
+                WHERE rs.geom && bounds.tile_4326
+                  AND ST_Intersects(rs.geom, bounds.tile_4326)
+                  {highway_filter}
+            ),
+            tile_features AS (
+                SELECT
+                    id,
+                    osm_id,
+                    name,
+                    highway,
+                    length_m,
+                    ST_AsMVTGeom(
+                        geom_3857,
+                        tile_3857,
+                        extent => :extent,
+                        buffer => :buffer,
+                        clip_geom => true
+                    ) AS geom
+                FROM filtered
+            )
+            SELECT COALESCE(ST_AsMVT(tile_features, 'roads', :extent, 'geom'), ''::bytea) AS tile
+            FROM tile_features
+            WHERE geom IS NOT NULL
+            """
+        ).bindparams(bindparam("highway_values", expanding=True))
+        query_params["highway_values"] = highways
+
+    tile = _execute(db, tile_query, query_params).scalar_one()
+    if isinstance(tile, memoryview):
+        tile = tile.tobytes()
+
+    return Response(
+        content=tile or b"",
+        media_type=MVT_MEDIA_TYPE,
+        headers={"Cache-Control": MVT_CACHE_CONTROL},
+    )
 
 
 @router.get("/roads/{road_id}")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,11 +1,18 @@
 from fastapi import FastAPI
-
+from fastapi.middleware.cors import CORSMiddleware
 from .api.roads import router as roads_router
 
 
 app = FastAPI(title="Urban Risk Analytics API")
 app.include_router(roads_router)
 
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 @app.get("/")
 def read_root():

--- a/backend/tests/integration_tests/test_roads_api.py
+++ b/backend/tests/integration_tests/test_roads_api.py
@@ -11,6 +11,9 @@ LEEDS_BBOX = {
 }
 
 LEEDS_POINT = {"lon": -1.5491, "lat": 53.8008}
+LEEDS_TILE_MID = {"z": 9, "x": 253, "y": 164}
+LEEDS_TILE_HIGH = {"z": 14, "x": 8121, "y": 5275}
+EMPTY_TILE = {"z": 9, "x": 56, "y": 318}
 
 
 def test_roads_bbox_returns_featurecollection():
@@ -80,4 +83,30 @@ def test_roads_invalid_bbox_returns_400():
         "limit": 10,
     }
     r = client.get("/roads", params=bad)
+    assert r.status_code == 400
+
+
+def test_roads_vector_tile_mid_zoom_returns_binary_tile():
+    r = client.get(f"/tiles/roads/{LEEDS_TILE_MID['z']}/{LEEDS_TILE_MID['x']}/{LEEDS_TILE_MID['y']}.mvt")
+    assert r.status_code == 200
+    assert r.headers["content-type"] == "application/vnd.mapbox-vector-tile"
+    assert r.headers["cache-control"] == "public, max-age=60"
+    assert len(r.content) > 0
+
+
+def test_roads_vector_tile_high_zoom_returns_binary_tile():
+    r = client.get(f"/tiles/roads/{LEEDS_TILE_HIGH['z']}/{LEEDS_TILE_HIGH['x']}/{LEEDS_TILE_HIGH['y']}.mvt")
+    assert r.status_code == 200
+    assert r.headers["content-type"] == "application/vnd.mapbox-vector-tile"
+    assert len(r.content) > 0
+
+
+def test_roads_vector_tile_empty_area_returns_200():
+    r = client.get(f"/tiles/roads/{EMPTY_TILE['z']}/{EMPTY_TILE['x']}/{EMPTY_TILE['y']}.mvt")
+    assert r.status_code == 200
+    assert r.headers["content-type"] == "application/vnd.mapbox-vector-tile"
+
+
+def test_roads_vector_tile_invalid_coordinates_return_400():
+    r = client.get("/tiles/roads/9/512/0.mvt")
     assert r.status_code == 400

--- a/backend/tests/smoke_tests/test_smoke_vector_tiles.py
+++ b/backend/tests/smoke_tests/test_smoke_vector_tiles.py
@@ -1,0 +1,47 @@
+from fastapi.testclient import TestClient
+
+from app.db import get_db
+from app.main import app
+
+
+class _FakeResult:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def scalar_one(self):
+        return self.payload
+
+
+class _FakeSession:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def execute(self, query, params):
+        return _FakeResult(self.payload)
+
+
+def _override_get_db():
+    yield _FakeSession(b"\x1a\x2b\x3c")
+
+
+client = TestClient(app)
+
+
+def test_vector_tile_route_returns_binary_response():
+    app.dependency_overrides[get_db] = _override_get_db
+    try:
+        response = client.get("/tiles/roads/9/253/164.mvt")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/vnd.mapbox-vector-tile"
+    assert response.headers["cache-control"] == "public, max-age=60"
+    assert response.content == b"\x1a\x2b\x3c"
+
+
+def test_vector_tile_route_rejects_out_of_range_coordinates():
+    response = client.get("/tiles/roads/9/512/0.mvt")
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Tile coordinates out of range for zoom level"


### PR DESCRIPTION
In this branch, what we did is we created a tiles version of our Rhodes API, which takes an x, y, and z parameter and converts the geospatial data into vector tiles, which is easy to render on the front end. The reason we did this was:
1. It was really hard to render the GeoJSON on the front end.
2. It didn't look as great.
3. It caused massive performance issues with CPU and memory in the browser spiking.
Hence, we researched with generative AI for good solutions to fix this, and the one they gave us was using vector tiles and WebGL on the front end.
How we did this is we use that x, y, which are what you're looking at and how zoomed in you are. We validate those and then we calculate the simplified torrents and highways, which is depending on how zoomed in you are, how much data are you going to see? Are you going to see really specific data about the small little roads, or are you going to just see big highways? Using that, we execute a PostgreSQL query which derives the data and then sends it back at the API, whether you're in a front-end or any other area, to use that data.
Now, one thing we also did was we also did some integration tests where we just added to our roads initial tests where we were testing the basic functions of the API using the client Docker using FastAPI testing. We also did some small smoke vector testing, which we will refactor later. That's all the testing we have already done. We might add some more unit testing for the smaller functions. We will do that in the future towards the end, where we really decide the testing platform we're going to do post MVP.